### PR TITLE
feat: show unknown achievements in table

### DIFF
--- a/src/data/achievements.json
+++ b/src/data/achievements.json
@@ -1,4 +1,10 @@
 {
+  "NEW_ACHIEVEMENT": {
+    "link": "",
+    "name": "Unknown Achievement",
+    "inGameDescription": "",
+    "unlockDescription": "Tracker doesn't know this achievement yet"
+  },
   "1": {
     "link": "Magdalene",
     "name": "Magdalene",

--- a/src/data/achievements.json
+++ b/src/data/achievements.json
@@ -1,8 +1,8 @@
 {
-  "NEW_ACHIEVEMENT": {
-    "link": "",
+  "NEW": {
+    "link": "Unknown",
     "name": "Unknown Achievement",
-    "inGameDescription": "",
+    "inGameDescription": "undefined",
     "unlockDescription": "Tracker doesn't know this achievement yet"
   },
   "1": {

--- a/src/fillPage.ts
+++ b/src/fillPage.ts
@@ -51,19 +51,25 @@ function fillAchievementsAddRow(i: number, tBody: HTMLTableElement) {
   const id = i.toString();
   rowData.push(id);
 
-  const key = id as keyof typeof achievements;
-  const description = achievements[key];
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (description === undefined) {
-    throw new Error(`Failed to find the achievement for ID: ${id}`);
+  const newAchievementKey = "NEW_ACHIEVEMENT";
+  let key = id as keyof typeof achievements;
+
+  // Unknown achievement.
+  if(achievements[key] === undefined){
+    key = newAchievementKey;
   }
+
+  const description = achievements[key];
   const { name, link, inGameDescription, unlockDescription } = description;
 
   const linkedName =
     link === "" ? name : `<a href=${WIKI_PREFIX}${link}>${name}</a>`;
   rowData.push(linkedName);
 
-  const image = `<img src="img/achievements/${id}.png" />`;
+  // Only add image if achievement is known.
+  const image =
+      key == newAchievementKey ? "" : `<img src="img/achievements/${id}.png" />`;
+
   rowData.push(image, inGameDescription, unlockDescription);
 
   addRow(tBody, rowData);

--- a/src/fillPage.ts
+++ b/src/fillPage.ts
@@ -10,6 +10,13 @@ import { getElement, hide, show, toggle } from "./utils.js";
 
 type Prefix = "achievements" | "collectibles" | "easter-eggs";
 
+interface AchievementJSON {
+  link: string;
+  name: string;
+  inGameDescription: string;
+  unlockDescription: string;
+}
+
 const SAVE_FILE_STATS_ID = "save-file-stats";
 const WIKI_PREFIX = "https://bindingofisaacrebirth.fandom.com/wiki/";
 const HIDE_TEXT = "Hide";
@@ -51,24 +58,18 @@ function fillAchievementsAddRow(i: number, tBody: HTMLTableElement) {
   const id = i.toString();
   rowData.push(id);
 
-  const newAchievementKey = "NEW_ACHIEVEMENT";
-  let key = id as keyof typeof achievements;
-
-  // Unknown achievement.
-  if(achievements[key] === undefined){
-    key = newAchievementKey;
-  }
-
-  const description = achievements[key];
-  const { name, link, inGameDescription, unlockDescription } = description;
+  const achievementsJSON = achievements as Record<string, AchievementJSON>;
+  const achievement = achievementsJSON[id] ?? achievements.NEW;
+  const { name, link, inGameDescription, unlockDescription } = achievement;
 
   const linkedName =
     link === "" ? name : `<a href=${WIKI_PREFIX}${link}>${name}</a>`;
   rowData.push(linkedName);
 
-  // Only add image if achievement is known.
   const image =
-      key == newAchievementKey ? "" : `<img src="img/achievements/${id}.png" />`;
+    achievement.name === achievements.NEW.name
+      ? ""
+      : `<img src="img/achievements/${id}.png" />`;
 
   rowData.push(image, inGameDescription, unlockDescription);
 

--- a/static/main.js
+++ b/static/main.js
@@ -671,13 +671,13 @@
     "97": () => _710,
     "98": () => _810,
     "99": () => _910,
-    NEW_ACHIEVEMENT: () => NEW_ACHIEVEMENT,
+    NEW: () => NEW,
     default: () => achievements_default
   });
-  var NEW_ACHIEVEMENT = {
-    link: "",
+  var NEW = {
+    link: "Unknown",
     name: "Unknown Achievement",
-    inGameDescription: "",
+    inGameDescription: "undefined",
     unlockDescription: "Tracker doesn't know this achievement yet"
   };
   var _ = {
@@ -4503,7 +4503,7 @@
     unlockDescription: "Unlock all the other achievements and collect every item in the game"
   };
   var achievements_default = {
-    NEW_ACHIEVEMENT,
+    NEW,
     "1": _,
     "2": _2,
     "3": _3,
@@ -19167,10 +19167,10 @@
     "97": () => _740,
     "98": () => _840,
     "99": () => _930,
-    NEW: () => NEW,
+    NEW: () => NEW2,
     default: () => items_default
   });
-  var NEW = {
+  var NEW2 = {
     name: "Unknown Item",
     shown: true,
     text: "Tracker doesn't know this item yet",
@@ -26445,7 +26445,7 @@
     introduced_in: "Repentance"
   };
   var items_default = {
-    NEW,
+    NEW: NEW2,
     "-1": _130,
     "1": _131,
     "2": _138,
@@ -27661,16 +27661,12 @@
     const rowData = [];
     const id = i.toString();
     rowData.push(id);
-    const newAchievementKey = "NEW_ACHIEVEMENT";
-    let key = id;
-    if (achievements_exports[key] === void 0) {
-      key = newAchievementKey;
-    }
-    const description = achievements_exports[key];
-    const { name, link, inGameDescription, unlockDescription } = description;
+    const achievementsJSON = achievements_exports;
+    const achievement = achievementsJSON[id] ?? NEW;
+    const { name, link, inGameDescription, unlockDescription } = achievement;
     const linkedName = link === "" ? name : `<a href=${WIKI_PREFIX}${link}>${name}</a>`;
     rowData.push(linkedName);
-    const image = key == newAchievementKey ? "" : `<img src="img/achievements/${id}.png" />`;
+    const image = achievement.name === NEW.name ? "" : `<img src="img/achievements/${id}.png" />`;
     rowData.push(image, inGameDescription, unlockDescription);
     addRow(tBody, rowData);
   }

--- a/static/main.js
+++ b/static/main.js
@@ -671,8 +671,15 @@
     "97": () => _710,
     "98": () => _810,
     "99": () => _910,
+    NEW_ACHIEVEMENT: () => NEW_ACHIEVEMENT,
     default: () => achievements_default
   });
+  var NEW_ACHIEVEMENT = {
+    link: "",
+    name: "Unknown Achievement",
+    inGameDescription: "",
+    unlockDescription: "Tracker doesn't know this achievement yet"
+  };
   var _ = {
     link: "Magdalene",
     name: "Magdalene",
@@ -4496,6 +4503,7 @@
     unlockDescription: "Unlock all the other achievements and collect every item in the game"
   };
   var achievements_default = {
+    NEW_ACHIEVEMENT,
     "1": _,
     "2": _2,
     "3": _3,
@@ -27653,15 +27661,16 @@
     const rowData = [];
     const id = i.toString();
     rowData.push(id);
-    const key = id;
-    const description = achievements_exports[key];
-    if (description === void 0) {
-      throw new Error(`Failed to find the achievement for ID: ${id}`);
+    const newAchievementKey = "NEW_ACHIEVEMENT";
+    let key = id;
+    if (achievements_exports[key] === void 0) {
+      key = newAchievementKey;
     }
+    const description = achievements_exports[key];
     const { name, link, inGameDescription, unlockDescription } = description;
     const linkedName = link === "" ? name : `<a href=${WIKI_PREFIX}${link}>${name}</a>`;
     rowData.push(linkedName);
-    const image = `<img src="img/achievements/${id}.png" />`;
+    const image = key == newAchievementKey ? "" : `<img src="img/achievements/${id}.png" />`;
     rowData.push(image, inGameDescription, unlockDescription);
     addRow(tBody, rowData);
   }


### PR DESCRIPTION
Previous behaviour: show "Failed to find the achievement" error message when unknown achievement id is found. New: produce all tables and include "this is an unknown achievement" as row data.